### PR TITLE
rename the addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-materializecss",
+  "name": "ember-materialize",
   "version": "0.0.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [


### PR DESCRIPTION
remove the "css" suffix from the addon name.

This corresponds better with the office Materialize project as well as making it shorter to type/remember ;)